### PR TITLE
Updated getopts and usage

### DIFF
--- a/src/steamcompmgr.c
+++ b/src/steamcompmgr.c
@@ -1713,21 +1713,11 @@ usage (char *program)
 	fprintf (stderr, "usage: %s [options]\n", program);
 	fprintf (stderr, "Options\n");
 	fprintf (stderr, "   -d display\n      Specifies which display should be managed.\n");
-	fprintf (stderr, "   -r radius\n      Specifies the blur radius for client-side shadows. (default 12)\n");
-	fprintf (stderr, "   -o opacity\n      Specifies the translucency for client-side shadows. (default .75)\n");
-	fprintf (stderr, "   -l left-offset\n      Specifies the left offset for client-side shadows. (default -15)\n");
-	fprintf (stderr, "   -t top-offset\n      Specifies the top offset for clinet-side shadows. (default -15)\n");
-	fprintf (stderr, "   -I fade-in-step\n      Specifies the opacity change between steps while fading in. (default 0.028)\n");
-	fprintf (stderr, "   -O fade-out-step\n      Specifies the opacity change between steps while fading out. (default 0.03)\n");
-	fprintf (stderr, "   -D fade-delta-time\n      Specifies the time between steps in a fade in milliseconds. (default 10)\n");
-	fprintf (stderr, "   -a\n      Use automatic server-side compositing. Faster, but no special effects.\n");
-	fprintf (stderr, "   -c\n      Draw client-side shadows with fuzzy edges.\n");
-	fprintf (stderr, "   -C\n      Avoid drawing shadows on dock/panel windows.\n");
-	fprintf (stderr, "   -f\n      Fade windows in/out when opening/closing.\n");
-	fprintf (stderr, "   -F\n      Fade windows during opacity changes.\n");
 	fprintf (stderr, "   -n\n      Normal client-side compositing with transparency support\n");
-	fprintf (stderr, "   -s\n      Draw server-side shadows with sharp edges.\n");
-	fprintf (stderr, "   -S\n      Enable synchronous operation (for debugging).\n");
+	fprintf (stderr, "   -S\n      Enable synchronous operation (for debugging)\n");
+	fprintf (stderr, "   -v\n      Draw debug information like FPS on screen\n");
+	fprintf (stderr, "   -V\n      Log events to standard output (for debugging)\n");
+	fprintf (stderr, "   -u\n      Enable undirected mode if possible\n");
 	exit (1);
 }
 
@@ -1817,7 +1807,7 @@ main (int argc, char **argv)
 	char	    *display = NULL;
 	int		    o;
 	
-	while ((o = getopt (argc, argv, "D:I:O:d:r:o:l:t:scnufFCaSvV")) != -1)
+	while ((o = getopt (argc, argv, "d:nSvVu")) != -1)
 	{
 		switch (o) {
 			case 'd':


### PR DESCRIPTION
The command line options for steamos-compositor displayed by the usage function weren't quite right and the getopt function was listening to options which aren't there. This patch fixes that.

I hope my description for the -u option makes sense, since I don't quite understand what it does. I went by what it is called in the code.