### PR TITLE
Update zotac.zone.oled.lua

### DIFF
--- a/scripts/00-gamescope/displays/zotac.zone.oled.lua
+++ b/scripts/00-gamescope/displays/zotac.zone.oled.lua
@@ -1,0 +1,57 @@
+-- colorimetry from DXQ7D0023 PDF specification
+local zotac_amoled_colorimetry = {
+   r = { x = 0.6396, y = 0.3300 },
+   g = { x = 0.2998, y = 0.5996 },
+   b = { x = 0.1503, y = 0.0595 },
+   w = { x = 0.3095, y = 0.3095 }
+}
+
+gamescope.config.known_displays.zotac_amoled = {
+    pretty_name = "DXQ7D0023 AMOLED",
+    dynamic_refresh_rates = {
+        60, 72, 90, 120,144
+    },
+    hdr = {
+        supported = true,
+        force_enabled = true,
+        eotf = gamescope.eotf.ST2084,
+        max_content_light_level = 993.486,
+        max_frame_average_luminance = 400,
+        min_content_light_level = 0.007
+    },
+    colorimetry = zotac_amoled_colorimetry,
+    dynamic_modegen = function(base_mode, refresh)
+        debug("Generating mode "..refresh.."Hz for DXQ7D0023 AMOLED")
+        local mode = base_mode
+
+        gamescope.modegen.set_resolution(mode, 1080, 1920)
+
+        -- Horizontal timings from PDF:       HFP, HSync, HBP
+        gamescope.modegen.set_h_timings(mode, 80, 44, 156)
+        -- Vertical timings from PDF: VFP=20, VSync=1, VBP=15
+        gamescope.modegen.set_v_timings(mode, 48, 2, 14)
+
+        mode.clock = gamescope.modegen.calc_max_clock(mode, refresh)
+        mode.vrefresh = gamescope.modegen.calc_vrefresh(mode)
+
+        return mode
+    end,
+    matches = function(display)
+        -- Match based on the EDID information
+        local lcd_types = {
+            { vendor = "ZDZ", model = "ZDZ0501" },
+            { vendor = "DXQ", model = "DXQ7D0023" },
+			{ vendor = "AYA", model = "AYAOLED_FHD" },
+        }
+
+        for index, value in ipairs(lcd_types) do
+            if value.vendor == display.vendor and value.model == display.model then
+                debug("[zotac_amoled] Matched vendor: "..value.vendor.." model: "..value.model)
+                return 5000
+            end
+        end
+
+        return -1
+    end
+}
+debug("Registered DXQ7D0023 AMOLED as a known display")


### PR DESCRIPTION
The handheld Ayaneo 3 shows washed out colours in game mode - colours look fine on desktop.
I got the vendor and model from my Ayaneo 3

> Block 0, Base EDID:
>   EDID Structure Version & Revision: 1.4
>   Vendor & Product Identification:
>     Manufacturer: AYA
>     Model: 275
>     Serial Number: 539232513 (0x20240901)
>     Made in: week 25 of 2024
>   Basic Display Parameters & Features:
>     Digital display
>     Bits per primary color channel: 10
>     DisplayPort interface
>     Maximum image size: 9 cm x 15 cm
>     Gamma: 2.20
>     Supported color formats: RGB 4:4:4, YCrCb 4:4:4
>     Default (sRGB) color space is primary color space
>     First detailed timing includes the native pixel format and preferred refresh rate
>   Color Characteristics:
>     Red  : 0.6396, 0.3300
>     Green: 0.2998, 0.5996
>     Blue : 0.1503, 0.0595
>     White: 0.3095, 0.3095
>   Established Timings I & II: none
>   Standard Timings: none
>   Detailed Timing Descriptors:
>     DTD 1:  1080x1920  120.000445 Hz   9:16   238.081 kHz    323.790000 MHz (154 mm x 87 mm)
>                  Hfront   80 Hsync  44 Hback  156 Hpol P
>                  Vfront   48 Vsync   2 Vback   14 Vpol P
>     DTD 2:  1080x1920  144.112458 Hz   9:16   285.919 kHz    388.850000 MHz (154 mm x 87 mm)
>                  Hfront   80 Hsync  44 Hback  156 Hpol P
>                  Vfront   48 Vsync   2 Vback   14 Vpol P
>     DTD 3:  1080x1920   60.001470 Hz   9:16   116.643 kHz    146.970000 MHz (154 mm x 87 mm)
>                  Hfront   90 Hsync  18 Hback   72 Hpol P
>                  Vfront   14 Vsync   2 Vback    8 Vpol P
>     Display Product Name: 'AYAOLED_FHD'
>   Extension blocks: 1
> Checksum: 0xf4

updated refresh rate - the panel supports it
corrected eotf

Not sure what to do from here! 

PS
first PR - ever - so be kind! thank you for the amazing work (: (:
I've been using bazzite / aurora extensively and I'd like to help.